### PR TITLE
Add "user-agent" to resolve "403 forbidden" issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function translate(text, opts) {
 
         return url + '?' + querystring.stringify(data);
     }).then(function (url) {
-        return got(url).then(function (res) {
+        return got(url, {headers: {'user-agent': 'Mozilla/5.0'}}).then(function (res) {
             var result = {
                 text: '',
                 from: {


### PR DESCRIPTION
``` bash
curl -A "Mozilla/5.0" "https://translate.google.cn/translate_a/single?client=t&sl=auto&tl=zh-cn&hl=zh-cn&dt=at&dt=bd&dt=ex&dt=ld&dt=md&dt=qca&dt=rw&dt=rm&dt=ss&dt=t&ie=UTF-8&oe=UTF-8&otf=1&ssel=0&tsel=0&kc=7&q=hello&tk=970599.543581"
```
return is 200 OK.

``` bash
curl "https://translate.google.cn/translate_a/single?client=t&sl=auto&tl=zh-cn&hl=zh-cn&dt=at&dt=bd&dt=ex&dt=ld&dt=md&dt=qca&dt=rw&dt=rm&dt=ss&dt=t&ie=UTF-8&oe=UTF-8&otf=1&ssel=0&tsel=0&kc=7&q=hello&tk=970599.543581"
```
return is 403.